### PR TITLE
Don't overwrite with blanks

### DIFF
--- a/DECS Excel Add-Ins/NotesParser.cs
+++ b/DECS Excel Add-Ins/NotesParser.cs
@@ -251,7 +251,7 @@ namespace DECS_Excel_Add_Ins
                             }
                         }
 
-                        targetRng.Offset[rowNumber - 1, 0].Value = String.Join(", ", extractedValues);
+                        targetRng.Offset[rowNumber - 1, 0].Value += String.Join(", ", extractedValues);
                     }
                     catch (System.ArgumentNullException)
                     {

--- a/DECS Excel Add-Ins/test files/valid_rules.xml
+++ b/DECS Excel Add-Ins/test files/valid_rules.xml
@@ -32,6 +32,12 @@
       <newColumn>Date of Exam</newColumn>
     </ExtractRule>
     <ExtractRule>
+	  <displayName>Get date that won't match</displayName>
+	  <enabled>true</enabled>
+	  <pattern>I received the vaccine on\s*(?:\d{1,2}/\d{1,2}/\d{4}, ?)*(\d{1,2}/\d{1,2}/\d{4})</pattern>
+	  <newColumn>Date of Exam</newColumn>
+	</ExtractRule>
+	<ExtractRule>
       <displayName>Get temperature</displayName>
       <enabled>true</enabled>
       <pattern>Air temperature:\s*(\d+\.?\d*)\s*(?: deg|°)F</pattern>


### PR DESCRIPTION
When using multiple rules pointing to the same results column, _append_ results, don't overwrite.