### PR TITLE
Be content-sensitive when formatting as DateTime.

### DIFF
--- a/.github/badges/last-commit-badge.svg
+++ b/.github/badges/last-commit-badge.svg
@@ -17,7 +17,7 @@
         <text x="40.0" y="14">last commit</text>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-        <text x="138.0" y="15" fill="#010101" fill-opacity=".3">June 20, 2024</text>
-        <text x="137.0" y="14">June 20, 2024</text>
+        <text x="138.0" y="15" fill="#010101" fill-opacity=".3">August 20, 2024</text>
+        <text x="137.0" y="14">August 20, 2024</text>
     </g>
 </svg>

--- a/DECS Excel Add-Ins/Formatter.cs
+++ b/DECS Excel Add-Ins/Formatter.cs
@@ -23,6 +23,7 @@ namespace DECS_Excel_Add_Ins
         private const double MAX_COLUMN_WIDTH = 30.0;
 
         private int lastColumn;
+        private int lastRow;
 
 
         internal Formatter() { }
@@ -115,6 +116,7 @@ namespace DECS_Excel_Add_Ins
         {
             Range originalSelection = worksheet.Application.Selection;
             lastColumn = worksheet.UsedRange.Columns.Count;
+            lastRow = worksheet.UsedRange.Rows.Count;
 
             // If the user has selected the first row, we won't be free to modify it.
             MoveOffFirstRow(originalSelection);
@@ -216,9 +218,10 @@ namespace DECS_Excel_Add_Ins
 
             for (int colOffset = 0; colOffset < lastColumn; colOffset++)
             {
-                string columnName = firstCell.Offset[0, colOffset].Value2.ToString();
+                Range topOfColumn = firstCell.Offset[0, colOffset];
+                string columnName = topOfColumn.Value2.ToString();
 
-                if (columnName.ToLower().Contains("date"))
+                if (columnName.ToLower().Contains("date") && Utilities.IsExcelDate(topOfColumn, lastRow))
                 {
                     try
                     {

--- a/DECS Excel Add-Ins/Utilities.cs
+++ b/DECS Excel Add-Ins/Utilities.cs
@@ -289,8 +289,8 @@ namespace DECS_Excel_Add_Ins
         internal static int FindLastRow(Worksheet sheet)
         {
             // Unhide All Cells and clear formats
-            sheet.Columns.ClearFormats();
-            sheet.Rows.ClearFormats();
+            //sheet.Columns.ClearFormats();
+            //sheet.Rows.ClearFormats();
 
             // Detect Last used Row, including cells that contains formulas that result in blank values
             
@@ -669,6 +669,41 @@ namespace DECS_Excel_Add_Ins
 
             newRange.Value2 = newColumnName;
             return newRange;
+        }
+
+        /// <summary>
+        /// Tests to see if column can be converted to Excel date.
+        /// </summary>
+        /// <param name="cellContents">String contents of a particular cell.</param>
+        /// <returns>DateTime</returns>
+        internal static bool IsExcelDate(Range column, int lastRow)
+        {
+            bool isExcelDate = true;
+            string cellContents = string.Empty;
+            DateTime pastDate = DateTime.Parse("1950-01-01");
+            DateTime futureDate = DateTime.Parse("2050-01-01");
+
+            for (int rowOffset = 1; rowOffset < (lastRow - 1); rowOffset++)
+            {
+                try
+                {
+                    cellContents = column.Offset[rowOffset, 0].Value2.ToString();
+                }
+                catch (Exception ex)
+                { 
+                    MessageBox.Show(ex.Message);
+                }
+
+                DateTime? convertedDate = ConvertExcelDate(cellContents);
+
+                if (convertedDate == null || convertedDate < pastDate || convertedDate > futureDate)
+                {
+                    isExcelDate = false;
+                    break;
+                }
+            }
+
+            return isExcelDate;
         }
 
         /// <summary>


### PR DESCRIPTION
Be content-sensitive when formatting as DateTime.