### PR TITLE
Don't include titles or trailing periods in provider names.

### DIFF
--- a/DECS Excel Add-Ins/EmailSearcher.cs
+++ b/DECS Excel Add-Ins/EmailSearcher.cs
@@ -20,7 +20,7 @@ namespace DECS_Excel_Add_Ins
     {
         private Microsoft.Office.Interop.Excel.Application application;
         private const string emailExtractor = @"(?<name>[^@]+)@";
-        private const string titleExtractor = @"Staff Directory: (?<name>[\w,\s\.'-]+)";
+        private const string titleExtractor = @"Staff Directory: (?<name>[\w\s'-]+,[\w\s'-]+)";
         private HtmlWeb web;
         private int lastRowInSheet;
         private Range providerNameRng;


### PR DESCRIPTION
Don't include titles or trailing periods in provider names.